### PR TITLE
Experiment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.edgelab</groupId>
     <artifactId>spring-opentracing</artifactId>
-    <version>debug</version>
+    <version>2019.06.20-b20</version>
     <packaging>jar</packaging>
     <description>Jaeger-based opentracing Spring integration</description>
 
@@ -13,13 +13,13 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-boot-dependencies.version>2.1.5.RELEASE</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.1.6.RELEASE</spring-boot-dependencies.version>
         <opentracing-spring-cloud-starter.version>0.3.2</opentracing-spring-cloud-starter.version>
         <jaeger-client.version>0.35.5</jaeger-client.version>
 
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
-        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-source-plugin.version>3.1.0</maven-source-plugin.version>
         <jacoco.version>0.8.4</jacoco.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.edgelab</groupId>
     <artifactId>spring-opentracing</artifactId>
-    <version>2019.06.20-b20</version>
+    <version>debug</version>
     <packaging>jar</packaging>
     <description>Jaeger-based opentracing Spring integration</description>
 
@@ -13,7 +13,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring-boot-dependencies.version>2.1.6.RELEASE</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.1.5.RELEASE</spring-boot-dependencies.version>
         <opentracing-spring-cloud-starter.version>0.3.2</opentracing-spring-cloud-starter.version>
         <jaeger-client.version>0.35.5</jaeger-client.version>
 

--- a/src/main/java/com/edgelab/opentracing/jaeger/JaegerTracerAutoConfiguration.java
+++ b/src/main/java/com/edgelab/opentracing/jaeger/JaegerTracerAutoConfiguration.java
@@ -14,7 +14,6 @@ import io.jaegertracing.spi.Sampler;
 import io.jaegertracing.spi.Sender;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration;
-import io.opentracing.util.ThreadLocalScopeManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
@@ -47,7 +46,7 @@ public class JaegerTracerAutoConfiguration {
             .build();
 
         return new JaegerTracer.Builder(properties.getServiceName())
-            .withScopeManager(new DiagnosticContextScopeManager(new ThreadLocalScopeManager()))
+            .withScopeManager(new DiagnosticContextScopeManager())
             .withReporter(reporter)
             .withSampler(sampler())
             .build();

--- a/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScope.java
+++ b/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScope.java
@@ -24,15 +24,15 @@ public class DiagnosticContextScope implements Scope {
         this.scopeManager = scopeManager;
         this.wrapped = wrapped;
         this.finishOnClose = finishOnClose;
-        this.toRestore = scopeManager.tlsScope.get();
-        this.scopeManager.tlsScope.set(this);
+        this.toRestore = scopeManager.getTlsScope().get();
+        this.scopeManager.getTlsScope().set(this);
 
         injectMdc(wrapped.context());
     }
 
     @Override
     public void close() {
-        if (scopeManager.tlsScope.get() != this) {
+        if (scopeManager.getTlsScope().get() != this) {
             // This shouldn't happen if users call methods in the expected order. Bail out.
             return;
         }
@@ -42,7 +42,7 @@ public class DiagnosticContextScope implements Scope {
         }
 
         // restore the previous scope
-        scopeManager.tlsScope.set(toRestore);
+        scopeManager.getTlsScope().set(toRestore);
 
         // and inject back the old MDC values
         if (toRestore != null && toRestore.wrapped != null) {

--- a/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScope.java
+++ b/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScope.java
@@ -41,8 +41,10 @@ public class DiagnosticContextScope implements Scope {
             wrapped.finish();
         }
 
+        // restore the previous scope
         scopeManager.tlsScope.set(toRestore);
 
+        // and inject back the old MDC values
         if (toRestore != null && toRestore.wrapped != null) {
             injectMdc(toRestore.wrapped.context());
         }

--- a/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScope.java
+++ b/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScope.java
@@ -1,0 +1,71 @@
+package com.edgelab.opentracing.mdc;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.SpanContext;
+import org.slf4j.MDC;
+
+import static com.edgelab.opentracing.mdc.DiagnosticContextScopeManager.SPAN_ID;
+import static com.edgelab.opentracing.mdc.DiagnosticContextScopeManager.TRACE_CONTEXT;
+import static com.edgelab.opentracing.mdc.DiagnosticContextScopeManager.TRACE_ID;
+
+public class DiagnosticContextScope implements Scope {
+
+    private final DiagnosticContextScopeManager scopeManager;
+    private final Span wrapped;
+    private final boolean finishOnClose;
+    private final DiagnosticContextScope toRestore;
+
+    DiagnosticContextScope(DiagnosticContextScopeManager scopeManager, Span wrapped) {
+        this(scopeManager, wrapped, false);
+    }
+
+    DiagnosticContextScope(DiagnosticContextScopeManager scopeManager, Span wrapped, boolean finishOnClose) {
+        this.scopeManager = scopeManager;
+        this.wrapped = wrapped;
+        this.finishOnClose = finishOnClose;
+        this.toRestore = scopeManager.tlsScope.get();
+
+        SpanContext context = wrapped.context();
+        mdcReplace(TRACE_ID, context.toTraceId());
+        mdcReplace(SPAN_ID, context.toSpanId());
+        mdcReplace(TRACE_CONTEXT, context.toString());
+
+        scopeManager.tlsScope.set(this);
+    }
+
+    @Override
+    public void close() {
+        if (scopeManager.tlsScope.get() != this) {
+            // This shouldn't happen if users call methods in the expected order. Bail out.
+            return;
+        }
+
+        if (finishOnClose) {
+            wrapped.finish();
+        }
+
+        scopeManager.tlsScope.set(toRestore);
+
+        if (toRestore != null && toRestore.wrapped != null) {
+            SpanContext context = toRestore.wrapped.context();
+            mdcReplace(TRACE_ID, context.toTraceId());
+            mdcReplace(SPAN_ID, context.toSpanId());
+            mdcReplace(TRACE_CONTEXT, context.toString());
+        }
+    }
+
+    @Override
+    public Span span() {
+        return wrapped;
+    }
+
+    private void mdcReplace(String key, String value) {
+        if (value != null) {
+            MDC.put(key, value);
+        } else {
+            MDC.remove(key);
+        }
+    }
+
+}

--- a/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScopeManager.java
+++ b/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScopeManager.java
@@ -16,13 +16,16 @@ public class DiagnosticContextScopeManager implements ScopeManager {
     @Override
     @Deprecated
     public Scope activate(Span span, boolean finishSpanOnClose) {
+        // skip the NoopScope optimization (deprecated method)
         return new DiagnosticContextScope(this, span, finishSpanOnClose);
     }
 
     @Override
     public Scope activate(Span span) {
-        Scope currentScope = tlsScope.get();
+        DiagnosticContextScope currentScope = tlsScope.get();
 
+        // avoid creating more duplicated scopes in ThreadLocal if the span is already activated
+        // similar optimization like CurrentTraceContext.maybeScope(TraceContext currentSpan) in Brave
         if (currentScope != null && currentScope.span() == span) {
             return NoopScope.INSTANCE;
         }
@@ -38,7 +41,7 @@ public class DiagnosticContextScopeManager implements ScopeManager {
 
     @Override
     public Span activeSpan() {
-        Scope scope = tlsScope.get();
+        DiagnosticContextScope scope = tlsScope.get();
         return scope == null ? null : scope.span();
     }
 

--- a/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScopeManager.java
+++ b/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScopeManager.java
@@ -4,6 +4,9 @@ import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
 import io.opentracing.noop.NoopScopeManager.NoopScope;
+import lombok.Getter;
+
+import static lombok.AccessLevel.PACKAGE;
 
 public class DiagnosticContextScopeManager implements ScopeManager {
 
@@ -11,7 +14,8 @@ public class DiagnosticContextScopeManager implements ScopeManager {
     public static final String TRACE_ID = "traceID";
     public static final String SPAN_ID = "spanID";
 
-    final ThreadLocal<DiagnosticContextScope> tlsScope = new ThreadLocal<>();
+    @Getter(PACKAGE)
+    private final ThreadLocal<DiagnosticContextScope> tlsScope = new ThreadLocal<>();
 
     @Override
     @Deprecated

--- a/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScopeManager.java
+++ b/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScopeManager.java
@@ -3,6 +3,7 @@ package com.edgelab.opentracing.mdc;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
+import io.opentracing.noop.NoopScopeManager.NoopScope;
 
 public class DiagnosticContextScopeManager implements ScopeManager {
 
@@ -21,8 +22,9 @@ public class DiagnosticContextScopeManager implements ScopeManager {
     @Override
     public Scope activate(Span span) {
         Scope currentScope = tlsScope.get();
+
         if (currentScope != null && currentScope.span() == span) {
-            return currentScope;
+            return NoopScope.INSTANCE;
         }
 
         return new DiagnosticContextScope(this, span);

--- a/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScopeManager.java
+++ b/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScopeManager.java
@@ -3,108 +3,41 @@ package com.edgelab.opentracing.mdc;
 import io.opentracing.Scope;
 import io.opentracing.ScopeManager;
 import io.opentracing.Span;
-import io.opentracing.SpanContext;
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
-import org.slf4j.MDC;
 
-import java.util.HashMap;
-import java.util.Map;
-
-@RequiredArgsConstructor
 public class DiagnosticContextScopeManager implements ScopeManager {
 
     public static final String TRACE_CONTEXT = "traceCtxt";
     public static final String TRACE_ID = "traceID";
     public static final String SPAN_ID = "spanID";
 
-    @NonNull
-    private final ScopeManager scopeManager;
+    final ThreadLocal<DiagnosticContextScope> tlsScope = new ThreadLocal<>();
 
     @Override
     @Deprecated
     public Scope activate(Span span, boolean finishSpanOnClose) {
-        // activate scope
-        Scope scope = scopeManager.activate(span, finishSpanOnClose);
-        Map<String, String> context = createContext(scope.span());
-
-        return new DiagnosticContextScope(scope, context);
+        return new DiagnosticContextScope(this, span, finishSpanOnClose);
     }
 
     @Override
     public Scope activate(Span span) {
-        // activate scope
-        Scope scope = scopeManager.activate(span);
-        Map<String, String> context = createContext(span);
+        Scope currentScope = tlsScope.get();
+        if (currentScope != null && currentScope.span() == span) {
+            return currentScope;
+        }
 
-        return new DiagnosticContextScope(scope, context);
+        return new DiagnosticContextScope(this, span);
     }
 
     @Override
     @Deprecated
     public Scope active() {
-        return scopeManager.active();
+        return tlsScope.get();
     }
 
     @Override
     public Span activeSpan() {
-        return scopeManager.activeSpan();
-    }
-
-    private Map<String, String> createContext(Span span) {
-        SpanContext context = span.context();
-
-        Map<String, String> map = new HashMap<>();
-        context.baggageItems().forEach(e -> map.put(e.getKey(), e.getValue()));
-
-        // here we rely on the toString() implementation of the SpanContext
-        // which prints trace id, span id, parent span id in a single block
-        map.put(TRACE_CONTEXT, context.toString());
-        map.put(TRACE_ID, context.toTraceId());
-        map.put(SPAN_ID, context.toSpanId());
-
-        return map;
-    }
-
-    public static class DiagnosticContextScope implements Scope {
-
-        private final Scope scope;
-        private final Map<String, String> previous = new HashMap<>();
-
-        DiagnosticContextScope(Scope scope, Map<String, String> context) {
-            this.scope = scope;
-
-            // initialize MDC
-            for (Map.Entry<String, String> entry : context.entrySet()) {
-                previous.put(entry.getKey(), MDC.get(entry.getKey()));
-                mdcReplace(entry.getKey(), entry.getValue());
-            }
-        }
-
-        @Override
-        public void close() {
-            scope.close();
-
-            // restore previous context
-            for (Map.Entry<String, String> entry : previous.entrySet()) {
-                mdcReplace(entry.getKey(), entry.getValue());
-            }
-        }
-
-        @Override
-        @Deprecated
-        public Span span() {
-            return scope.span();
-        }
-
-        private static void mdcReplace(String key, String value) {
-            if (value != null) {
-                MDC.put(key, value);
-            } else {
-                MDC.remove(key);
-            }
-        }
-
+        Scope scope = tlsScope.get();
+        return scope == null ? null : scope.span();
     }
 
 }

--- a/src/test/java/com/edgelab/opentracing/TraceLoggingTests.java
+++ b/src/test/java/com/edgelab/opentracing/TraceLoggingTests.java
@@ -1,10 +1,12 @@
 package com.edgelab.opentracing;
 
 import com.edgelab.opentracing.TraceLoggingTests.TestController;
+import com.edgelab.opentracing.mdc.DiagnosticContextScopeManager;
 import io.opentracing.Tracer;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -52,13 +54,13 @@ public class TraceLoggingTests {
 
         private Mono<Integer> doubleMono(Integer x) {
             return Mono.fromSupplier(() -> {
-//                assertThat(tracer.activeSpan()).isNotNull();
-//                assertThat(tracer.activeSpan().getBaggageItem(BAGGAGE_KEY)).isEqualTo(BAGGAGE_VALUE);
+                assertThat(tracer.activeSpan()).isNotNull();
+                assertThat(tracer.activeSpan().getBaggageItem(BAGGAGE_KEY)).isEqualTo(BAGGAGE_VALUE);
 
-//                assertThat(MDC.get(DiagnosticContextScopeManager.TRACE_CONTEXT)).isNotEmpty();
-//                assertThat(MDC.get(DiagnosticContextScopeManager.TRACE_ID)).isNotEmpty();
-//                assertThat(MDC.get(DiagnosticContextScopeManager.SPAN_ID)).isNotEmpty();
-//                assertThat(MDC.get(BAGGAGE_KEY)).isEqualTo(BAGGAGE_VALUE);
+                assertThat(MDC.get(DiagnosticContextScopeManager.TRACE_CONTEXT)).isNotEmpty();
+                assertThat(MDC.get(DiagnosticContextScopeManager.TRACE_ID)).isNotEmpty();
+                assertThat(MDC.get(DiagnosticContextScopeManager.SPAN_ID)).isNotEmpty();
+                assertThat(MDC.get(BAGGAGE_KEY)).isEqualTo(BAGGAGE_VALUE);
 
                 log.info("You should see logs with tracing info for element '{}'", x);
                 return x * 2;

--- a/src/test/java/com/edgelab/opentracing/TraceLoggingTests.java
+++ b/src/test/java/com/edgelab/opentracing/TraceLoggingTests.java
@@ -1,12 +1,10 @@
 package com.edgelab.opentracing;
 
 import com.edgelab.opentracing.TraceLoggingTests.TestController;
-import com.edgelab.opentracing.mdc.DiagnosticContextScopeManager;
 import io.opentracing.Tracer;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -54,13 +52,13 @@ public class TraceLoggingTests {
 
         private Mono<Integer> doubleMono(Integer x) {
             return Mono.fromSupplier(() -> {
-                assertThat(tracer.activeSpan()).isNotNull();
-                assertThat(tracer.activeSpan().getBaggageItem(BAGGAGE_KEY)).isEqualTo(BAGGAGE_VALUE);
+//                assertThat(tracer.activeSpan()).isNotNull();
+//                assertThat(tracer.activeSpan().getBaggageItem(BAGGAGE_KEY)).isEqualTo(BAGGAGE_VALUE);
 
-                assertThat(MDC.get(DiagnosticContextScopeManager.TRACE_CONTEXT)).isNotEmpty();
-                assertThat(MDC.get(DiagnosticContextScopeManager.TRACE_ID)).isNotEmpty();
-                assertThat(MDC.get(DiagnosticContextScopeManager.SPAN_ID)).isNotEmpty();
-                assertThat(MDC.get(BAGGAGE_KEY)).isEqualTo(BAGGAGE_VALUE);
+//                assertThat(MDC.get(DiagnosticContextScopeManager.TRACE_CONTEXT)).isNotEmpty();
+//                assertThat(MDC.get(DiagnosticContextScopeManager.TRACE_ID)).isNotEmpty();
+//                assertThat(MDC.get(DiagnosticContextScopeManager.SPAN_ID)).isNotEmpty();
+//                assertThat(MDC.get(BAGGAGE_KEY)).isEqualTo(BAGGAGE_VALUE);
 
                 log.info("You should see logs with tracing info for element '{}'", x);
                 return x * 2;


### PR DESCRIPTION
I rewrote the implementation of this `DiagnosticContextScopeManager` by looking at how it's implemented in Spring Sleuth. Actually, your C* data access layer done by Spring create huge amounts of Subscribers which is quite expensive with opentracing + decorated scopes (how it's implemented for MDC injections). However, on Brave side (no wonder it's the most matured solution..), it has already some optimizations with a helper [class](https://github.com/openzipkin/brave/blob/master/brave/src/main/java/brave/propagation/CurrentTraceContext.java#L134). So the Spring Sleuth way is not expensive anymore.

In the end, the fix is basically avoid creating duplicated scopes if they are already in the ThreadLocal placeholder. I tested locally with Lipo, the performance is back to normal (the same as no tracing at all).