### PR TITLE
Fix mixed-up baggage items

### DIFF
--- a/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScope.java
+++ b/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScope.java
@@ -3,12 +3,14 @@ package com.edgelab.opentracing.mdc;
 import io.opentracing.Scope;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
+import lombok.extern.slf4j.Slf4j;
 import org.slf4j.MDC;
 
 import static com.edgelab.opentracing.mdc.DiagnosticContextScopeManager.SPAN_ID;
 import static com.edgelab.opentracing.mdc.DiagnosticContextScopeManager.TRACE_CONTEXT;
 import static com.edgelab.opentracing.mdc.DiagnosticContextScopeManager.TRACE_ID;
 
+@Slf4j
 class DiagnosticContextScope implements Scope {
 
     private final DiagnosticContextScopeManager scopeManager;
@@ -28,6 +30,10 @@ class DiagnosticContextScope implements Scope {
         this.toRestore = scopeManager.getTlsScope().get();
         this.shouldRestore = toRestore != null && toRestore.wrapped != null;
         this.scopeManager.getTlsScope().set(this);
+
+        if (toRestore != null && toRestore.wrapped == null) {
+            log.error("Null span");
+        }
 
         if (shouldRestore) {
             cleanBaggage(toRestore.wrapped.context());

--- a/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScope.java
+++ b/src/main/java/com/edgelab/opentracing/mdc/DiagnosticContextScope.java
@@ -15,6 +15,7 @@ class DiagnosticContextScope implements Scope {
     private final Span wrapped;
     private final boolean finishOnClose;
     private final DiagnosticContextScope toRestore;
+    private final boolean shouldRestore;
 
     DiagnosticContextScope(DiagnosticContextScopeManager scopeManager, Span wrapped) {
         this(scopeManager, wrapped, false);
@@ -25,8 +26,12 @@ class DiagnosticContextScope implements Scope {
         this.wrapped = wrapped;
         this.finishOnClose = finishOnClose;
         this.toRestore = scopeManager.getTlsScope().get();
+        this.shouldRestore = toRestore != null && toRestore.wrapped != null;
         this.scopeManager.getTlsScope().set(this);
 
+        if (shouldRestore) {
+            cleanBaggage(toRestore.wrapped.context());
+        }
         injectMdc(wrapped.context());
     }
 
@@ -45,7 +50,8 @@ class DiagnosticContextScope implements Scope {
         scopeManager.getTlsScope().set(toRestore);
 
         // and inject back the old MDC values
-        if (toRestore != null && toRestore.wrapped != null) {
+        if (shouldRestore) {
+            cleanBaggage(wrapped.context());
             injectMdc(toRestore.wrapped.context());
         } else {
             cleanMdc(wrapped.context());
@@ -68,6 +74,10 @@ class DiagnosticContextScope implements Scope {
         MDC.remove(TRACE_ID);
         MDC.remove(SPAN_ID);
         MDC.remove(TRACE_CONTEXT);
+        cleanBaggage(context);
+    }
+
+    private void cleanBaggage(SpanContext context) {
         context.baggageItems().forEach(e -> MDC.remove(e.getKey()));
     }
 


### PR DESCRIPTION
On recco2 we spotted two unexpected behaviors:
- When a new `DiagnosticContextScope` is created, it does not remove from the MDC the baggage items of the cached scope.
- Wrapped span's baggage items are not removed from the MDC when the cached scope is restored.

On our side, it leads to incorrect `consumer` and `internal-caller` mixings.